### PR TITLE
Explicit Panic When Overflowing on `fetch_sub()`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     name: Compile Debug
     runs-on: ubuntu-latest
     steps:
-    - name: Fetch Changes
+    - name: Build Debug
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.host }}
@@ -50,7 +50,7 @@ jobs:
     needs: [build-debug]
     runs-on: ubuntu-latest
     steps:
-    - name: Fetch Changes
+    - name: Test Debug
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.host }}
@@ -72,7 +72,7 @@ jobs:
     needs: [test-debug]
     runs-on: ubuntu-latest
     steps:
-    - name: Fetch Changes
+    - name: Build Release
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.host }}
@@ -94,7 +94,7 @@ jobs:
     needs: [build-release]
     runs-on: ubuntu-latest
     steps:
-    - name: Fetch Changes
+    - name: Test Release
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.host }}

--- a/src/waker64.rs
+++ b/src/waker64.rs
@@ -68,6 +68,9 @@ impl Waker64 {
     pub fn fetch_sub(&self, val: u64) -> u64 {
         let s = unsafe { &mut *self.0.get() };
         let old = *s;
+        if val > *s {
+            panic!("fetch_sub() would overflow");
+        }
         *s -= val;
         old
     }

--- a/src/waker64.rs
+++ b/src/waker64.rs
@@ -144,7 +144,7 @@ mod tests {
     #[bench]
     fn bench_fetch_sub(b: &mut Bencher) {
         let x: u64 = rand::thread_rng().gen_range(0..64);
-        let w64: Waker64 = Waker64::new(0);
+        let w64: Waker64 = Waker64::new(64);
 
         b.iter(|| {
             let val: u64 = black_box(x);


### PR DESCRIPTION
Description
--------------

This PR is a workaround for #3.

Summary of Changes
------------------------

- Introduced an explicit `panic()` when overflow happens
- Fixed regression tests to not panic.